### PR TITLE
Only animate swipe transitions to prevent no view controller managing…

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -153,7 +153,7 @@
 #pragma mark - Actions
 
 - (void)segmentedTapped:(CarbonTabSwipeSegmentedControl *)segment {
-    [self moveToIndex:segment.selectedSegmentIndex withAnimation:YES];
+    [self moveToIndex:segment.selectedSegmentIndex withAnimation:NO];
 }
 
 - (void)moveToIndex:(NSUInteger)index withAnimation:(BOOL)animate {


### PR DESCRIPTION
… visible view crash when selecting a tab.