### PR TITLE
Merge ios 13 support

### DIFF
--- a/CarbonKit.podspec
+++ b/CarbonKit.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "CarbonKit"
-  s.version      = "2.2.2"
+  s.version      = "2.3.0"
   s.summary      = "CarbonKit - iOS Components (Obj-C & Swift)"
 
   s.description  = "CarbonKit is an open source iOS library that includes powerful and beauty UI components."

--- a/CarbonKit/CarbonTabSwipeSegmentedControl.m
+++ b/CarbonKit/CarbonTabSwipeSegmentedControl.m
@@ -63,6 +63,14 @@
               rightSegmentState:UIControlStateNormal
                      barMetrics:UIBarMetricsDefault];
 
+        [self setClipsToBounds:FALSE];
+        [self setBackgroundImage:[UIImage new]
+                        forState:UIControlStateNormal
+                      barMetrics:UIBarMetricsDefault];
+        [self setBackgroundImage:[UIImage new]
+                        forState:UIControlStateSelected
+                      barMetrics:UIBarMetricsDefault];
+
         // Fix indicator frame
         if (items) {
             self.indicatorMinX = [self getMinXForSegmentAtIndex:self.selectedSegmentIndex];

--- a/CarbonKit/CarbonTabSwipeSegmentedControl.m
+++ b/CarbonKit/CarbonTabSwipeSegmentedControl.m
@@ -92,7 +92,7 @@
     CGFloat totalWidth = 0;
     for (UIView *segment in self.segments) {
         NSInteger index = [self.segments indexOfObject:segment];
-        CGFloat width = [self getWidthForSegmentAtIndex:index];
+        CGFloat width = [self getWidthForTitleAtIndex:index];
         CGRect segmentRect = segment.frame;
         segmentRect.origin.x = totalWidth;
         segmentRect.size.width = width + _tabExtraWidth;
@@ -103,6 +103,9 @@
     _tabExtraWidth = 0;
 
     // Set the width of UISegmentedControl to fit all segments
+    if (totalWidth < self.superview.frame.size.width) {
+        totalWidth = self.superview.frame.size.width;
+    }
     rect.size.width = totalWidth;
     self.frame = rect;
 
@@ -187,6 +190,10 @@
         return CGRectGetWidth(self.frame) - CGRectGetMinX(self.segments[index].frame);
     }
     return CGRectGetWidth(self.segments[index].frame);
+}
+
+- (CGFloat)getWidthForTitleAtIndex:(NSUInteger)index {
+    return [[self titleForSegmentAtIndex:index] sizeWithAttributes:@{NSFontAttributeName : [UIFont boldSystemFontOfSize:14]}].width;
 }
 
 - (CGFloat)getWidth {

--- a/CarbonKit/CarbonTabSwipeSegmentedControl.m
+++ b/CarbonKit/CarbonTabSwipeSegmentedControl.m
@@ -92,7 +92,7 @@
     CGFloat totalWidth = 0;
     for (UIView *segment in self.segments) {
         NSInteger index = [self.segments indexOfObject:segment];
-        CGFloat width = [self getWidthForTitleAtIndex:index];
+        CGFloat width = [self getWidthForSegmentAtIndex:index];
         CGRect segmentRect = segment.frame;
         segmentRect.origin.x = totalWidth;
         segmentRect.size.width = width + _tabExtraWidth;
@@ -103,9 +103,6 @@
     _tabExtraWidth = 0;
 
     // Set the width of UISegmentedControl to fit all segments
-    if (totalWidth < self.superview.frame.size.width) {
-        totalWidth = self.superview.frame.size.width;
-    }
     rect.size.width = totalWidth;
     self.frame = rect;
 
@@ -190,10 +187,6 @@
         return CGRectGetWidth(self.frame) - CGRectGetMinX(self.segments[index].frame);
     }
     return CGRectGetWidth(self.segments[index].frame);
-}
-
-- (CGFloat)getWidthForTitleAtIndex:(NSUInteger)index {
-    return [[self titleForSegmentAtIndex:index] sizeWithAttributes:@{NSFontAttributeName : [UIFont boldSystemFontOfSize:14]}].width;
 }
 
 - (CGFloat)getWidth {


### PR DESCRIPTION
Prevents a white image appearing over the currently selected segment and discoloration of the navigation bar in iOS 13.

Tabs are now left-aligned on iOS 13.